### PR TITLE
Add python cli testing to travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
 language: rust
 rust:
   - stable
+addons:
+  language:
+      python
 matrix:
   fast_finish: true
+  include:
+    - python: 3.6
+
+before_install:
+  - ./tests/travis-before-install.sh
+
+script:
+  - ./tests/travis-test.sh

--- a/tests/travis-before-install.sh
+++ b/tests/travis-before-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eo pipefail
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+pushd $parent_path > /dev/null
+virtualenv test-venv
+
+source test-venv/bin/activate
+pip install -U pip setuptools
+pip install -U testtools python-subunit os-testr stestr
+popd > /dev/null

--- a/tests/travis-test.sh
+++ b/tests/travis-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eo pipefail
+parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+
+pushd $parent_path > /dev/null
+test-venv/bin/python -m subunit.run test_command | test-venv/bin/subunit-trace
+popd > /dev/null


### PR DESCRIPTION
This commit adds support for running the newly added python cli tests to
the travis ci configuration for the repo. This will validate we don't
break anything with future changes.