### PR TITLE
Bump subunit-rust and prepare for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "junitxml2subunit"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "clap",
@@ -153,9 +153,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "subunit-rust"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c224a2a6f0a6862ed4de8129236e202918cce183356cfd765ca98f5bef36cdc"
+checksum = "0dc14ebb2401905557b28304c7411676799bd953a6934e2d6cdb30dfd103ba8a"
 dependencies = [
  "byteorder",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junitxml2subunit"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "A tool to convert junitxml files to subunit v2"
 license = "GPL-3.0"
@@ -10,7 +10,7 @@ keywords = ["subunit", "junitxml"]
 categories = ["development-tools::testing"]
 
 [dependencies]
-subunit-rust = "0.1"
+subunit-rust = "0.1.3"
 quick-xml = "0.17.2"
 chrono = "0.4"
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ junitxml2subunit
 [![junitxml2subunit on Travis CI][travis-image]][travis]
 [![junitxml2subunit on crates.io][cratesio-image]][cratesio]
 
-[travis-image]: https://travis-ci.org/mtreinish/junitxml2subunit.svg?branch=master
+[travis-image]: https://travis-ci.com/mtreinish/junitxml2subunit.svg?branch=master
 [travis]: https://travis-ci.org/mtreinish/junitxml2subunit
 [cratesio-image]: https://img.shields.io/crates/v/junitxml2subunit.svg
 [cratesio]: https://crates.io/crates/junitxml2subunit
@@ -32,3 +32,6 @@ print the subunit v2 stream for that file to STDOUT. For example:
 ```
 $ junitxml2subunit results.xml
 ```
+
+Optionally there is a `-o`/`--output` flag which can be used to write the
+subunit v2 stream to a file.

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn _process_failure<T: Write>(
 }
 fn main() {
     let matches = App::new("junitxml2subunit")
-        .version("1.0.0")
+        .version("1.0.1")
         .about("Convert JUnit XML to Subunit v2")
         .arg(
             Arg::with_name("PATH")


### PR DESCRIPTION
This commit bumps the version of subunit-rust used to fix some compile
time issues when building from source and then bumps the
junitxml2subunit version to prepare for release.