### PR TITLE
Bump version to prepare for 1.1.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "junitxml2subunit"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "junitxml2subunit"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Matthew Treinish <mtreinish@kortar.org>"]
 description = "A tool to convert junitxml files to subunit v2"
 license = "GPL-3.0"


### PR DESCRIPTION
This commit bumps the version string in the Cargo.toml to prepare for
the pending 1.1.0 release.